### PR TITLE
zero_init_acknak config option

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -2800,7 +2800,7 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
   if (!compare_and_update_counts(acknack.count.value, reader->acknack_recvd_count_)) {
     VDBG((LM_WARNING, "(%P|%t) RtpsUdpDataLink::received(ACKNACK) "
       "WARNING Count indicates duplicate, dropping\n"));
-      return;
+    return;
   }
 
   const bool is_final = acknack.smHeader.flags & RTPS::FLAG_F;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -695,6 +695,7 @@ private:
   void send_heartbeat_replies(const DCPS::MonotonicTimePoint& now);
   void check_heartbeats(const DCPS::MonotonicTimePoint& now);
 
+  bool zero_init_acknak_;
   CORBA::Long best_effort_heartbeat_count_;
 
   typedef void (RtpsUdpDataLink::*PMF)();

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
@@ -35,6 +35,7 @@ RtpsUdpInst::RtpsUdpInst(const OPENDDS_STRING& name)
   , ttl_(1)
   , max_message_size_(RtpsUdpSendStrategy::UDP_MAX_MESSAGE_SIZE)
   , nak_depth_(0)
+  , zero_init_acknak_(false)
   , quick_reply_ratio_(0.1)
   , nak_response_delay_(0, 200*1000 /*microseconds*/) // default from RTPS
   , heartbeat_period_(1) // no default in RTPS spec
@@ -101,6 +102,8 @@ RtpsUdpInst::load(ACE_Configuration_Heap& cf,
   GET_CONFIG_VALUE(cf, sect, ACE_TEXT("quick_reply_ratio"), quick_reply_ratio_, double);
 
   GET_CONFIG_VALUE(cf, sect, ACE_TEXT("ttl"), ttl_, unsigned char);
+
+  GET_CONFIG_VALUE(cf, sect, ACE_TEXT("zero_init_acknak"), zero_init_acknak_, bool);
 
   GET_CONFIG_TIME_VALUE(cf, sect, ACE_TEXT("nak_response_delay"),
                         nak_response_delay_);

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.h
@@ -38,6 +38,7 @@ public:
 
   size_t max_message_size_;
   size_t nak_depth_;
+  bool zero_init_acknak_;
   double quick_reply_ratio_;
   TimeDuration nak_response_delay_, heartbeat_period_,
     heartbeat_response_delay_, handshake_timeout_, durable_data_timeout_;


### PR DESCRIPTION
I created a [transport] config option for rtps_udp which when set 1 will enable zero based initialization of acknaks, but defaults to 0 to not break interaction with old opendds.

I tested this using the messenger test and by editing rtps.ini to add the following under [transport]

`zero_init_acknak=1`

If zero_init_acknak is set to 1, it will run the code from the first 3 commits on this branch, otherwise it will run the old code prior to this branch.