### PR TITLE
Read and take are slow for a large number of instances

### DIFF
--- a/dds/DCPS/GroupRakeData.cpp
+++ b/dds/DCPS/GroupRakeData.cpp
@@ -48,7 +48,7 @@ GroupRakeData::get_datareaders(DDS::DataReaderSeq & readers)
   CORBA::ULong i = 0;
   SortedSet::iterator itEnd = this->sorted_.end();
   for (SortedSet::iterator it = this->sorted_.begin(); it != itEnd; ++it) {
-    RcHandle<DDS::DataReader> reader = it->si_->instance_state_->data_reader().lock();
+    RcHandle<DDS::DataReader> reader = it->si_->data_reader().lock();
     if (reader) {
       readers[i++] = DDS::DataReader::_duplicate(reader.in());
     } else {

--- a/dds/DCPS/GroupRakeData.h
+++ b/dds/DCPS/GroupRakeData.h
@@ -27,6 +27,8 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
+class SubscriptionInstance;
+
 /// Rake is an abbreviation for "read or take".  This class manages the
 /// results from a read() or take() operation, which are the received_data
 /// and the info_seq sequences passed in by-reference from the user.
@@ -37,7 +39,7 @@ public:
   /// Returns false if the sample will definitely not be part of the
   /// resulting dataset, however if this returns true it still may be
   /// excluded (due to sorting and max_samples).
-  bool insert_sample(ReceivedDataElement* sample, SubscriptionInstance_rch i,
+  bool insert_sample(ReceivedDataElement* sample, RcHandle<SubscriptionInstance> i,
                      size_t index_in_instance);
 
   void get_datareaders (DDS::DataReaderSeq & readers);

--- a/dds/DCPS/InstanceState.h
+++ b/dds/DCPS/InstanceState.h
@@ -33,6 +33,72 @@ class ReceivedDataElement;
 class InstanceState;
 typedef RcHandle<InstanceState> InstanceState_rch;
 
+// data structures used by copy_into()
+typedef OPENDDS_VECTOR(CORBA::ULong) IndexList;
+
+struct InstanceData {
+  bool most_recent_generation_;
+  size_t MRSIC_index_;
+  IndexList sampleinfo_positions_;
+  CORBA::Long MRSIC_disposed_gc_;
+  CORBA::Long MRSIC_nowriters_gc_;
+  CORBA::Long MRS_disposed_gc_;
+  CORBA::Long MRS_nowriters_gc_;
+
+  InstanceData()
+    : most_recent_generation_(false)
+    , MRSIC_index_(0)
+    , MRSIC_disposed_gc_(0)
+    , MRSIC_nowriters_gc_(0)
+    , MRS_disposed_gc_(0)
+    , MRS_nowriters_gc_(0) {}
+};
+
+class InstanceStateUpdateList {
+public:
+  struct InstanceStateUpdate {
+    DDS::InstanceHandle_t handle;
+    CORBA::ULong previous_state;
+    CORBA::ULong current_state;
+
+    InstanceStateUpdate(DDS::InstanceHandle_t a_handle,
+                        CORBA::ULong a_previous_state,
+                        CORBA::ULong a_current_state)
+      : handle(a_handle)
+      , previous_state(a_previous_state)
+      , current_state(a_current_state)
+    {}
+  };
+
+  void add(DDS::InstanceHandle_t handle,
+           CORBA::ULong previous_state,
+           CORBA::ULong current_state)
+  {
+    if (current_state != previous_state) {
+      list_.push_back(InstanceStateUpdate(handle, previous_state, current_state));
+    }
+  }
+
+  void remove(DDS::InstanceHandle_t handle)
+  {
+    set_.insert(handle);
+  }
+
+  typedef OPENDDS_VECTOR(InstanceStateUpdate) List;
+  typedef List::const_iterator const_add_iterator;
+  const_add_iterator add_begin() const { return list_.begin(); }
+  const_add_iterator add_end() const { return list_.end(); }
+
+  typedef OPENDDS_SET(DDS::InstanceHandle_t) Set;
+  typedef Set::const_iterator const_remove_iterator;
+  const_remove_iterator remove_begin() const { return set_.begin(); }
+  const_remove_iterator remove_end() const { return set_.end(); }
+
+private:
+  List list_;
+  Set set_;
+};
+
 /**
  * @class InstanceState
  *
@@ -47,7 +113,6 @@ typedef RcHandle<InstanceState> InstanceState_rch;
 class OpenDDS_Dcps_Export InstanceState : public ReactorInterceptor {
 public:
   InstanceState(DataReaderImpl* reader,
-                ACE_Recursive_Thread_Mutex& lock,
                 DDS::InstanceHandle_t handle);
 
   virtual ~InstanceState();
@@ -75,31 +140,29 @@ public:
   /// This flag is used by concrete DataReader to determine whether
   /// it should notify listener. If state is not changed, the dispose
   /// message is ignored.
-  bool dispose_was_received(const PublicationId& writer_id);
+  bool dispose_was_received(const PublicationId& writer_id,
+                            InstanceStateUpdateList& isul);
 
   /// UNREGISTER message received for this instance.
   /// Return flag indicates whether the instance state was changed.
   /// This flag is used by concrete DataReader to determine whether
   /// it should notify listener. If state is not changed, the unregister
   /// message is ignored.
-  bool unregister_was_received(const PublicationId& writer_id);
+  bool unregister_was_received(const PublicationId& writer_id,
+                               InstanceStateUpdateList& isul);
 
   /// Data sample received for this instance.
-  void data_was_received(const PublicationId& writer_id);
+  void data_was_received(const PublicationId& writer_id,
+                         InstanceStateUpdateList& isul);
 
   /// LIVELINESS message received for this DataWriter.
-  void lively(const PublicationId& writer_id);
+  void lively(const PublicationId& writer_id,
+              InstanceStateUpdateList& isul);
 
   /// A read or take operation has been performed on this instance.
-  void accessed();
+  void accessed(InstanceStateUpdateList& isul);
 
   bool most_recent_generation(ReceivedDataElement* item) const;
-
-  /// DataReader has become empty.  Returns true if the instance was released.
-  bool empty(bool value);
-
-  /// Schedule a pending release of resources.
-  void schedule_pending();
 
   /// Schedule an immediate release of resources.
   void schedule_release();
@@ -107,23 +170,13 @@ public:
   /// Cancel a scheduled or pending release of resources.
   void cancel_release();
 
-  /// Remove the instance if it's instance has no samples
-  /// and no writers.
-  /// Returns true if the instance was released.
-  bool release_if_empty();
-
-  /// Remove the instance immediately.
-  void release();
-
   /// Returns true if the writer is a writer of this instance.
   bool writes_instance(const PublicationId& writer_id) const
   {
-    ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex, guard, lock_, false);
     return writers_.count(writer_id);
   }
 
   WeakRcHandle<DataReaderImpl> data_reader() const;
-  void state_updated() const;
 
   virtual int handle_timeout(const ACE_Time_Value& current_time,
                              const void* arg);
@@ -150,10 +203,61 @@ public:
   /// Return string representation of the instance state mask passed
   static OPENDDS_STRING instance_state_mask_string(DDS::InstanceStateMask mask);
 
+  static inline CORBA::ULong combine_state(DDS::SampleStateMask sample_states,
+                                           DDS::ViewStateMask view_states,
+                                           DDS::InstanceStateMask instance_states)
+  {
+    return (sample_states << 5) | (view_states << 3) | instance_states;
+  }
+
+  CORBA::ULong combined_state() const
+  {
+    return combined_state_i();
+  }
+
+  void inc_not_read_count(InstanceStateUpdateList& isul)
+  {
+    const CORBA::ULong previous_state = combined_state_i();
+    ++not_read_count_;
+    isul.add(handle_, previous_state, combined_state_i());
+  }
+
+  void inc_read_count(InstanceStateUpdateList& isul)
+  {
+    const CORBA::ULong previous_state = combined_state_i();
+    --not_read_count_;
+    ++read_count_;
+    isul.add(handle_, previous_state, combined_state_i());
+  }
+
+  void dec_not_read_count(InstanceStateUpdateList& isul)
+  {
+    const CORBA::ULong previous_state = combined_state_i();
+    --not_read_count_;
+    isul.add(handle_, previous_state, combined_state_i());
+  }
+
+  void dec_read_count(InstanceStateUpdateList& isul)
+  {
+    const CORBA::ULong previous_state = combined_state_i();
+    --read_count_;
+    isul.add(handle_, previous_state, combined_state_i());
+  }
+
+  bool release_pending() const
+  {
+    return release_pending_;
+  }
+
 private:
   bool reactor_is_shut_down() const;
-
-  ACE_Recursive_Thread_Mutex& lock_;
+  CORBA::ULong combined_state_i() const
+  {
+    const DDS::SampleStateKind sample_states =
+      (not_read_count_ ? DDS::NOT_READ_SAMPLE_STATE : 0) |
+      (read_count_ ? DDS::READ_SAMPLE_STATE : 0);
+    return combine_state(sample_states, view_state_, instance_state_);
+  }
 
   /**
    * Current instance state.
@@ -185,6 +289,9 @@ private:
    */
   DDS::ViewStateKind view_state_;
 
+  size_t not_read_count_;
+  size_t read_count_;
+
   /// Number of times the instance state changes
   /// from NOT_ALIVE_DISPOSED to ALIVE.
   size_t disposed_generation_count_;
@@ -192,11 +299,6 @@ private:
   /// Number of times the instance state changes
   /// from NOT_ALIVE_NO_WRITERS to ALIVE.
   size_t no_writers_generation_count_;
-
-  /**
-   * Keep track of whether the DataReader is empty or not.
-   */
-  bool empty_;
 
   /**
    * Keep track of whether the instance is waiting to be released.
@@ -215,7 +317,7 @@ private:
    * empty -- that it contains no more sample data.
    */
   WeakRcHandle<DataReaderImpl> reader_;
-  DDS::InstanceHandle_t handle_;
+  const DDS::InstanceHandle_t handle_;
 
   RepoIdSet writers_;
   PublicationId owner_;

--- a/dds/DCPS/OwnershipManager.h
+++ b/dds/DCPS/OwnershipManager.h
@@ -28,6 +28,7 @@ namespace OpenDDS {
 namespace DCPS {
 
 class DataReaderImpl;
+class SubscriptionInstance;
 
 class OpenDDS_Dcps_Export OwnershipManager {
 public:
@@ -65,7 +66,7 @@ public:
   };
 
   typedef OPENDDS_VECTOR(WriterInfo) WriterInfos;
-  typedef OPENDDS_VECTOR(InstanceState_rch) InstanceStateVec;
+  typedef OPENDDS_VECTOR(RcHandle<SubscriptionInstance>) InstanceStateVec;
 
   struct OwnershipWriterInfos {
     WriterInfo owner_;
@@ -136,17 +137,16 @@ public:
   /**
   * Determine if the provided publication can be the owner.
   */
-  bool select_owner(const DDS::InstanceHandle_t& instance_handle,
+  bool select_owner(RcHandle<SubscriptionInstance> instance,
                     const PublicationId& pub_id,
-                    const CORBA::Long& ownership_strength,
-                    InstanceState_rch instance_state);
+                    const CORBA::Long& ownership_strength);
 
   /**
   * Remove an owner of the specified instance.
   */
   void remove_owner(const DDS::InstanceHandle_t& instance_handle);
 
-  void remove_instance(InstanceState* instance_state);
+  void remove_instance(RcHandle<SubscriptionInstance> instance);
 
   /**
   * Update the ownership strength of a publication.

--- a/dds/DCPS/RakeData.h
+++ b/dds/DCPS/RakeData.h
@@ -11,7 +11,6 @@
 #include /**/ "ace/pre.h"
 #include "dcps_export.h"
 #include "ReceivedDataElementList.h"
-#include "SubscriptionInstance.h"
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 # pragma once
@@ -22,11 +21,13 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
+class SubscriptionInstance;
+
 /// Rake is an abbreviation for "read or take".  This struct holds the
 /// data used by the data structures in RakeResults<T>.
 struct OpenDDS_Dcps_Export RakeData {
   ReceivedDataElement* rde_;
-  SubscriptionInstance_rch si_;
+  RcHandle<SubscriptionInstance> si_;
   size_t index_in_instance_;
 };
 

--- a/dds/DCPS/RakeResults_T.h
+++ b/dds/DCPS/RakeResults_T.h
@@ -24,6 +24,8 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
+class SubscriptionInstance;
+
 enum Operation_t { DDS_OPERATION_READ, DDS_OPERATION_TAKE };
 
 /// Rake is an abbreviation for "read or take".  This class manages the
@@ -40,12 +42,13 @@ public:
 #ifndef OPENDDS_NO_QUERY_CONDITION
               DDS::QueryCondition_ptr cond,
 #endif
-              Operation_t oper);
+              Operation_t oper,
+              InstanceStateUpdateList& isul);
 
   /// Returns false if the sample will definitely not be part of the
   /// resulting dataset, however if this returns true it still may be
   /// excluded (due to sorting and max_samples).
-  bool insert_sample(ReceivedDataElement* sample, SubscriptionInstance_rch i,
+  bool insert_sample(ReceivedDataElement* sample, RcHandle<SubscriptionInstance> i,
                      size_t index_in_instance);
 
   bool copy_to_user();
@@ -66,6 +69,7 @@ private:
   DDS::QueryCondition_ptr cond_;
 #endif
   Operation_t oper_;
+  InstanceStateUpdateList& isul_;
 
   class SortedSetCmp {
   public:
@@ -95,19 +99,6 @@ private:
 
   // Contains data for all other use cases
   OPENDDS_VECTOR(RakeData) unsorted_;
-
-  // data structures used by copy_into()
-  typedef OPENDDS_VECTOR(CORBA::ULong) IndexList;
-  struct InstanceData {
-    bool most_recent_generation_;
-    size_t MRSIC_index_;
-    IndexList sampleinfo_positions_;
-    CORBA::Long MRSIC_disposed_gc_, MRSIC_nowriters_gc_,
-    MRS_disposed_gc_, MRS_nowriters_gc_;
-    InstanceData() : most_recent_generation_(false), MRSIC_index_(0),
-      MRSIC_disposed_gc_(0), MRSIC_nowriters_gc_(0), MRS_disposed_gc_(0),
-      MRS_nowriters_gc_(0) {}
-  };
 };
 
 } // namespace DCPS

--- a/dds/DCPS/ReceivedDataElementList.cpp
+++ b/dds/DCPS/ReceivedDataElementList.cpp
@@ -52,8 +52,8 @@ void OpenDDS::DCPS::ReceivedDataElement::operator delete(void* memory, ACE_New_A
   operator delete(memory);
 }
 
-OpenDDS::DCPS::ReceivedDataElementList::ReceivedDataElementList(InstanceState_rch instance_state)
-  : head_(0), tail_(0), size_(0), instance_state_(instance_state)
+OpenDDS::DCPS::ReceivedDataElementList::ReceivedDataElementList()
+  : head_(0), tail_(0), size_(0)
 {
 }
 
@@ -76,16 +76,14 @@ OpenDDS::DCPS::ReceivedDataElementList::apply_all(
   }
 }
 
-bool
+void
 OpenDDS::DCPS::ReceivedDataElementList::remove(
   ReceivedDataFilter& match,
   bool eval_all)
 {
   if (!head_) {
-    return false;
+    return;
   }
-
-  bool released = false;
 
   for (ReceivedDataElement* item = head_ ; item != 0 ;
        item = item->next_data_sample_) {
@@ -118,21 +116,14 @@ OpenDDS::DCPS::ReceivedDataElementList::remove(
           item->previous_data_sample_ ;
       }
 
-      if (instance_state_ && size_ == 0) {
-        // let the instance know it is empty
-        released = released || instance_state_->empty(true);
-      }
-
       if (!eval_all) break;
     }
   }
-
-  return released;
 }
 
-bool
+void
 OpenDDS::DCPS::ReceivedDataElementList::remove(ReceivedDataElement *data_sample)
 {
   IdentityFilter match(data_sample);
-  return remove(match, false); // short-circuit evaluation
+  remove(match, false); // short-circuit evaluation
 }

--- a/dds/DCPS/ReceivedDataElementList.h
+++ b/dds/DCPS/ReceivedDataElementList.h
@@ -19,8 +19,8 @@
 #include "DataSampleHeader.h"
 #include "Definitions.h"
 #include "GuidUtils.h"
-#include "InstanceState.h"
 #include "Time_Helper.h"
+#include "TimeTypes.h"
 #include "unique_ptr.h"
 
 #include "dds/DdsDcpsInfrastructureC.h"
@@ -205,7 +205,7 @@ public:
 
 class OpenDDS_Dcps_Export ReceivedDataElementList {
 public:
-  explicit ReceivedDataElementList(InstanceState_rch instance_state = InstanceState_rch());
+  ReceivedDataElementList();
 
   ~ReceivedDataElementList();
 
@@ -214,11 +214,9 @@ public:
   // adds a data sample to the end of the list
   void add(ReceivedDataElement* data_sample);
 
-  // returns true if the instance was released
-  bool remove(ReceivedDataElement* data_sample);
+  void remove(ReceivedDataElement* data_sample);
 
-  // returns true if the instance was released
-  bool remove(ReceivedDataFilter& match, bool eval_all);
+  void remove(ReceivedDataFilter& match, bool eval_all);
 
   ReceivedDataElement* remove_head();
   ReceivedDataElement* remove_tail();
@@ -231,9 +229,6 @@ public:
 
   /// Number of elements in the list.
   ssize_t size_;
-
-private:
-  InstanceState_rch instance_state_;
 }; // ReceivedDataElementList
 
 } // namespace DCPS

--- a/dds/DCPS/ReceivedDataElementList.inl
+++ b/dds/DCPS/ReceivedDataElementList.inl
@@ -32,10 +32,6 @@ OpenDDS::DCPS::ReceivedDataElementList::add(ReceivedDataElement *data_sample)
     data_sample->previous_data_sample_ = tail_;
     tail_ = data_sample;
   }
-
-  if (instance_state_) {
-    instance_state_->empty(false);
-  }
 }
 
 ACE_INLINE

--- a/dds/DCPS/SubscriptionInstance.h
+++ b/dds/DCPS/SubscriptionInstance.h
@@ -13,6 +13,10 @@
 #include "ReceivedDataStrategy.h"
 #include "InstanceState.h"
 #include "RcObject.h"
+#include "RakeResults_T.h"
+#include "Observer.h"
+#include "ValueWriter.h"
+#include "GroupRakeData.h"
 
 #include "dds/DdsDcpsInfrastructureC.h"
 
@@ -26,6 +30,39 @@ namespace OpenDDS {
 namespace DCPS {
 
 class DataReaderImpl;
+class GroupRakeData;
+
+OpenDDS_Dcps_Export inline
+void sample_info(DDS::SampleInfo& sample_info,
+                 const ReceivedDataElement* ptr)
+{
+  sample_info.sample_rank = 0;
+
+  // generation_rank =
+  //    (MRSIC.disposed_generation_count +
+  //     MRSIC.no_writers_generation_count)
+  //  - (S.disposed_generation_count +
+  //     S.no_writers_generation_count)
+  //
+  sample_info.generation_rank =
+      (sample_info.disposed_generation_count +
+          sample_info.no_writers_generation_count) -
+          sample_info.generation_rank;
+
+  // absolute_generation_rank =
+  //     (MRS.disposed_generation_count +
+  //      MRS.no_writers_generation_count)
+  //   - (S.disposed_generation_count +
+  //      S.no_writers_generation_count)
+  //
+  sample_info.absolute_generation_rank =
+      (static_cast<CORBA::Long>(ptr->disposed_generation_count_) +
+          static_cast<CORBA::Long>(ptr->no_writers_generation_count_)) -
+          sample_info.absolute_generation_rank;
+
+  sample_info.opendds_reserved_publication_seq = ptr->sequence_.getValue();
+}
+
 
 /**
   * @class SubscriptionInstance
@@ -37,20 +74,567 @@ class OpenDDS_Dcps_Export SubscriptionInstance : public RcObject {
 public:
   SubscriptionInstance(DataReaderImpl* reader,
                        const DDS::DataReaderQos& qos,
-                       ACE_Recursive_Thread_Mutex& lock,
                        DDS::InstanceHandle_t handle,
                        bool owns_handle);
 
   ~SubscriptionInstance();
 
-  /// Instance state for this instance
-  const InstanceState_rch instance_state_;
+  DDS::InstanceHandle_t instance_handle() const
+  {
+    return instance_handle_;
+  }
 
-  /// Sequence number of the move recent data sample received
+  long deadline_timer_id() const
+  {
+    return deadline_timer_id_;
+  }
+
+  void deadline_timer_id(long dti)
+  {
+    deadline_timer_id_ = dti;
+  }
+
+  MonotonicTimePoint last_accepted() const
+  {
+    return last_accepted_;
+  }
+
+  void last_accepted(const MonotonicTimePoint& mtp)
+  {
+    last_accepted_ = mtp;
+  }
+
+  void set_last_accepted()
+  {
+    last_accepted_.set_to_now();
+  }
+
+  void accessed(InstanceStateUpdateList& isul)
+  {
+    instance_state_->accessed(isul);
+  }
+
+  CORBA::ULong combined_state() const
+  {
+    return instance_state_->combined_state();
+  }
+
+  void lively(const PublicationId& writer_id,
+              InstanceStateUpdateList& isul)
+  {
+    instance_state_->lively(writer_id, isul);
+  }
+
+  void data_was_received(const PublicationId& writer_id,
+                         InstanceStateUpdateList& isul)
+  {
+    return instance_state_->data_was_received(writer_id, isul);
+  }
+
+  bool dispose_was_received(const PublicationId& writer_id,
+                            InstanceStateUpdateList& isul)
+  {
+    return instance_state_->dispose_was_received(writer_id, isul);
+  }
+
+  bool unregister_was_received(const PublicationId& writer_id,
+                               InstanceStateUpdateList& isul)
+  {
+    return instance_state_->unregister_was_received(writer_id, isul);
+  }
+
+  size_t disposed_generation_count() const
+  {
+    return instance_state_->disposed_generation_count();
+  }
+
+  size_t no_writers_generation_count() const
+  {
+    return instance_state_->no_writers_generation_count();
+  }
+
+  bool writes_instance(const PublicationId& writer_id) const
+  {
+    return instance_state_->writes_instance(writer_id);
+  }
+
+  bool is_last(const PublicationId& writer_id)
+  {
+    return instance_state_->is_last(writer_id);
+  }
+
+  PublicationId& get_owner ()
+  {
+    return instance_state_->get_owner();
+  }
+
+  WeakRcHandle<DataReaderImpl> data_reader() const
+  {
+    return instance_state_->data_reader();
+  }
+
+  bool registered()
+  {
+    return instance_state_->registered();
+  }
+
+  void registered (bool flag)
+  {
+    instance_state_->registered(flag);
+  }
+
+  void reset_ownership (DDS::InstanceHandle_t instance)
+  {
+    instance_state_->reset_ownership(instance);
+  }
+
+  void set_owner (const PublicationId& owner)
+  {
+    instance_state_->set_owner(owner);
+  }
+
+  bool is_exclusive () const
+  {
+    return instance_state_->is_exclusive();
+  }
+
+  DDS::InstanceStateKind instance_state() const
+  {
+    return instance_state_->instance_state();
+  }
+
+  void cancel_release()
+  {
+    instance_state_->cancel_release();
+  }
+
+  CORBA::ULong sample_count() const
+  {
+    return rcvd_samples_.size_;
+  }
+
+  DDS::SampleStateKind head_sample_state() const
+  {
+    return rcvd_samples_.head_->sample_state_;
+  }
+
+  void discard_oldest_sample(InstanceStateUpdateList& isul)
+  {
+    // Discard the oldest previously-read sample
+    OpenDDS::DCPS::ReceivedDataElement *item = rcvd_samples_.head_;
+    remove(item, isul);
+    item->dec_ref();
+  }
+
+  OpenDDS::DCPS::ReceivedDataElement* remove_head(InstanceStateUpdateList& isul)
+  {
+    OpenDDS::DCPS::ReceivedDataElement* head_ptr = rcvd_samples_.head_;
+    remove(head_ptr, isul);
+    return head_ptr;
+  }
+
+  bool no_coherent_change() const
+  {
+#ifndef OPENDDS_NO_OBJECT_MODEL_PROFILE
+    for (ReceivedDataElement *item = rcvd_samples_.head_;
+         item != 0; item = item->next_data_sample_) {
+      if (!item->coherent_change_) {
+        return true;
+      }
+    }
+    return false;
+#else
+    return true;
+#endif
+  }
+
+  bool has_zero_copies() const
+  {
+    for (OpenDDS::DCPS::ReceivedDataElement *item = rcvd_samples_.head_;
+         item != 0; item = item->next_data_sample_) {
+      if (item->zero_copy_cnt_ > 0) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  void get_ordered_data(GroupRakeData& data,
+                        GroupRakeData& group_coherent_ordered_data,
+                        DDS::SampleStateMask sample_states, DDS::ViewStateMask view, DDS::InstanceStateMask inst)
+  {
+    if (instance_state_->match(view, inst)) {
+      size_t i = 0;
+      for (ReceivedDataElement* item = rcvd_samples_.head_; item != 0; item = item->next_data_sample_) {
+        if ((item->sample_state_ & sample_states) && !item->coherent_change_) {
+          data.insert_sample(item, rchandle_from(this), ++i);
+          group_coherent_ordered_data.insert_sample(item, rchandle_from(this), ++i);
+        }
+      }
+    }
+  }
+
+  template <typename MessageType>
+  bool read_next_sample(MessageType& received_data,
+                        DDS::SampleInfo& sample_info_ref,
+                        Observer_rch observer,
+                        const ValueWriterDispatcher* vwd,
+                        DDS::DataReader* data_reader,
+                        InstanceStateUpdateList& isul)
+  {
+    bool found_data = false;
+    bool most_recent_generation = false;
+
+    for (ReceivedDataElement* item = rcvd_samples_.head_; !found_data && item; item = item->next_data_sample_) {
+#ifndef OPENDDS_NO_OBJECT_MODEL_PROFILE
+      if (item->coherent_change_) continue;
+#endif
+
+      if (item->sample_state_ & DDS::NOT_READ_SAMPLE_STATE) {
+        if (item->registered_data_) {
+          received_data = *static_cast<MessageType*>(item->registered_data_);
+        }
+        instance_state_->sample_info(sample_info_ref, item);
+        read(item, isul);
+
+        if (observer && item->registered_data_ && vwd) {
+          Observer::Sample s(sample_info_ref.instance_handle, sample_info_ref.instance_state, *item, *vwd);
+          observer->on_sample_read(data_reader, s);
+        }
+
+        if (!most_recent_generation) {
+          most_recent_generation = instance_state_->most_recent_generation(item);
+        }
+        found_data = true;
+      }
+    }
+
+    if (found_data) {
+      if (most_recent_generation) {
+        instance_state_->accessed(isul);
+      }
+      // Get the sample_ranks, generation_ranks, and
+      // absolute_generation_ranks for this info_seq
+      sample_info(sample_info_ref, rcvd_samples_.tail_);
+    }
+
+    return found_data;
+  }
+
+  template <typename MessageType>
+  bool take_next_sample(MessageType& received_data,
+                        DDS::SampleInfo& sample_info_ref,
+                        Observer_rch observer,
+                        const ValueWriterDispatcher* vwd,
+                        DDS::DataReader* data_reader,
+                        InstanceStateUpdateList& isul)
+  {
+    bool found_data = false;
+    bool most_recent_generation = false;
+
+    OpenDDS::DCPS::ReceivedDataElement* tail = 0;
+    OpenDDS::DCPS::ReceivedDataElement* next;
+    OpenDDS::DCPS::ReceivedDataElement* item = rcvd_samples_.head_;
+    while (!found_data && item) {
+#ifndef OPENDDS_NO_OBJECT_MODEL_PROFILE
+      if (item->coherent_change_) {
+        item = item->next_data_sample_;
+        continue;
+      }
+#endif
+      if (item->sample_state_ & DDS::NOT_READ_SAMPLE_STATE) {
+        if (item->registered_data_) {
+          received_data = *static_cast<MessageType*>(item->registered_data_);
+        }
+        instance_state_->sample_info(sample_info_ref, item);
+        read(item, isul);
+
+        if (observer && item->registered_data_ && vwd) {
+          Observer::Sample s(sample_info_ref.instance_handle, sample_info_ref.instance_state, *item, *vwd);
+          observer->on_sample_taken(data_reader, s);
+        }
+
+        if (!most_recent_generation) {
+          most_recent_generation = instance_state_->most_recent_generation(item);
+        }
+
+        if (item == rcvd_samples_.tail_) {
+          tail = rcvd_samples_.tail_;
+          item = item->next_data_sample_;
+
+        } else {
+          next = item->next_data_sample_;
+
+          remove(item, isul);
+          item->dec_ref();
+
+          item = next;
+        }
+
+        found_data = true;
+      }
+    }
+
+    if (found_data) {
+      if (most_recent_generation) {
+        instance_state_->accessed(isul);
+      }
+
+      //
+      // Get the sample_ranks, generation_ranks, and
+      // absolute_generation_ranks for this info_seq
+      //
+      if (tail) {
+        sample_info(sample_info_ref, tail);
+
+        remove(tail, isul);
+        tail->dec_ref();
+
+      } else {
+        sample_info(sample_info_ref, rcvd_samples_.tail_);
+      }
+    }
+
+    return found_data;
+  }
+
+  template <typename MessageSequenceType>
+  void read(DDS::SampleStateMask sample_states,
+            RakeResults<MessageSequenceType>& results,
+            Observer_rch observer,
+            const ValueWriterDispatcher* vwd,
+            DDS::DataReader* data_reader)
+  {
+    size_t i = 0;
+    for (ReceivedDataElement* item = rcvd_samples_.head_; item; item = item->next_data_sample_) {
+      if ((item->sample_state_ & sample_states)
+#ifndef OPENDDS_NO_OBJECT_MODEL_PROFILE
+          && !item->coherent_change_
+#endif
+          ) {
+        results.insert_sample(item, rchandle_from(this), ++i);
+
+        if (observer && item->registered_data_ && vwd) {
+          Observer::Sample s(instance_handle_, instance_state_->instance_state(), *item, *vwd);
+          observer->on_sample_read(data_reader, s);
+        }
+      }
+    }
+  }
+
+  template <typename MessageSequenceType>
+  void take(DDS::SampleStateMask sample_states,
+            RakeResults<MessageSequenceType>& results,
+            Observer_rch observer,
+            const ValueWriterDispatcher* vwd,
+            DDS::DataReader* data_reader)
+  {
+    size_t i = 0;
+    for (ReceivedDataElement* item = rcvd_samples_.head_; item; item = item->next_data_sample_) {
+      if ((item->sample_state_ & sample_states)
+#ifndef OPENDDS_NO_OBJECT_MODEL_PROFILE
+          && !item->coherent_change_
+#endif
+          ) {
+        results.insert_sample(item, rchandle_from(this), ++i);
+
+        if (observer && item->registered_data_ && vwd) {
+          Observer::Sample s(instance_handle_, instance_state_->instance_state(), *item, *vwd);
+          observer->on_sample_taken(data_reader, s);
+        }
+      }
+    }
+  }
+
+  template <typename MessageSequenceType>
+  void read_instance(DDS::SampleStateMask sample_states,
+                     DDS::ViewStateMask view_states,
+                     DDS::InstanceStateMask instance_states,
+                     RakeResults<MessageSequenceType>& results,
+                     Observer_rch observer,
+                     const ValueWriterDispatcher* vwd,
+                     DDS::DataReader* data_reader)
+  {
+    if (instance_state_->match(view_states, instance_states)) {
+      size_t i = 0;
+      for (ReceivedDataElement* item = rcvd_samples_.head_; item; item = item->next_data_sample_) {
+        if ((item->sample_state_ & sample_states)
+#ifndef OPENDDS_NO_OBJECT_MODEL_PROFILE
+            && !item->coherent_change_
+#endif
+            ) {
+          results.insert_sample(item, rchandle_from(this), ++i);
+          if (observer && item->registered_data_ && vwd) {
+            Observer::Sample s(instance_handle_, instance_state_->instance_state(), *item, *vwd);
+            observer->on_sample_read(data_reader, s);
+          }
+        }
+      }
+    }
+  }
+
+  template <typename MessageSequenceType>
+  void take_instance(DDS::SampleStateMask sample_states,
+                     DDS::ViewStateMask view_states,
+                     DDS::InstanceStateMask instance_states,
+                     RakeResults<MessageSequenceType>& results,
+                     Observer_rch observer,
+                     const ValueWriterDispatcher* vwd,
+                     DDS::DataReader* data_reader)
+  {
+    if (instance_state_->match(view_states, instance_states)) {
+      size_t i = 0;
+      for (ReceivedDataElement* item = rcvd_samples_.head_; item; item = item->next_data_sample_) {
+        if ((item->sample_state_ & sample_states)
+#ifndef OPENDDS_NO_OBJECT_MODEL_PROFILE
+            && !item->coherent_change_
+#endif
+            ) {
+          results.insert_sample(item, rchandle_from(this), ++i);
+          if (observer && item->registered_data_ && vwd) {
+            Observer::Sample s(instance_handle_, instance_state_->instance_state(), *item, *vwd);
+            observer->on_sample_taken(data_reader, s);
+          }
+        }
+      }
+    }
+  }
+
+  template <typename MessageType>
+  bool contains_sample_filtered(DDS::SampleStateMask sample_states,
+                                bool filter_has_non_key_fields,
+                                const OpenDDS::DCPS::FilterEvaluator& evaluator,
+                                const DDS::StringSeq& params)
+  {
+    for (ReceivedDataElement* item = rcvd_samples_.head_; item != 0; item = item->next_data_sample_) {
+      if ((item->sample_state_ & sample_states)
+#ifndef OPENDDS_NO_OBJECT_MODEL_PROFILE
+          && !item->coherent_change_
+#endif
+          && item->registered_data_) {
+        if (!item->valid_data_ && filter_has_non_key_fields) {
+          continue;
+        }
+        if (evaluator.eval(*static_cast<MessageType*>(item->registered_data_), params)) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  typedef OPENDDS_MAP(SubscriptionInstance*, InstanceData) InstanceMap;
+  typedef OPENDDS_SET(SubscriptionInstance*) InstanceSet;
+
+  template <class FwdIter>
+    void copy_into(CORBA::ULong idx,
+                   DDS::SampleInfoSeq& info_seq,
+                   FwdIter iter,
+                   InstanceMap& inst_map,
+                   InstanceSet& released_instances,
+                   bool take,
+                   InstanceStateUpdateList& isul)
+  {
+    ReceivedDataElement* rde = iter->rde_;
+
+    // 2. Per-sample SampleInfo (not the three *_rank variables) and state
+    instance_state_->sample_info(info_seq[idx], rde);
+    read(rde, isul);
+
+    // 3. Record some info about per-instance SampleInfo (*_rank) so that
+    //    we can fill in the ranks after the loop has completed
+    std::pair<typename InstanceMap::iterator, bool> result =
+      inst_map.insert(std::make_pair(this, InstanceData()));
+    InstanceData& id = result.first->second;
+
+    if (result.second) { // first time we've seen this Instance
+      ReceivedDataElement& mrs = *rcvd_samples_.tail_;
+      id.MRS_disposed_gc_ =
+        static_cast<CORBA::Long>(mrs.disposed_generation_count_);
+      id.MRS_nowriters_gc_ =
+        static_cast<CORBA::Long>(mrs.no_writers_generation_count_);
+    }
+
+    if (iter->index_in_instance_ >= id.MRSIC_index_) {
+      id.MRSIC_index_ = iter->index_in_instance_;
+      id.MRSIC_disposed_gc_ =
+        static_cast<CORBA::Long>(rde->disposed_generation_count_);
+      id.MRSIC_nowriters_gc_ =
+        static_cast<CORBA::Long>(rde->no_writers_generation_count_);
+    }
+
+    if (!id.most_recent_generation_) {
+      id.most_recent_generation_ =
+        instance_state_->most_recent_generation(rde);
+    }
+
+    id.sampleinfo_positions_.push_back(idx);
+
+    // 4. Take
+    if (take) {
+      // If removing the sample releases it
+      if (remove(rde, isul)) {
+        // Prevent access of the SampleInfo, below
+        released_instances.insert(this);
+      }
+      rde->dec_ref();
+    }
+  }
+
+  void add(ReceivedDataElement* ptr,
+           InstanceStateUpdateList& isul)
+  {
+    rcvd_strategy_->add(ptr);
+    instance_state_->inc_not_read_count(isul);
+  }
+
+  void accept_coherent(const PublicationId& writer,
+                       const RepoId& publisher)
+  {
+    rcvd_strategy_->accept_coherent(writer, publisher);
+  }
+
+  void reject_coherent(const PublicationId& writer,
+                       const RepoId& publisher)
+  {
+    rcvd_strategy_->reject_coherent(writer, publisher);
+  }
+
+  void set_current_sample_time()
+  {
+    last_sample_tv_ = cur_sample_tv_;
+    cur_sample_tv_.set_to_now();
+  }
+
+  const MonotonicTimePoint& current_sample_time()
+  {
+    return cur_sample_tv_;
+  }
+
+  const MonotonicTimePoint& last_sample_time()
+  {
+    return last_sample_tv_;
+  }
+
+  void last_sequence(const SequenceNumber& sn)
+  {
+    last_sequence_ = sn;
+  }
+
+  void purge_data()
+  {
+    while (rcvd_samples_.size_ > 0) {
+      OpenDDS::DCPS::ReceivedDataElement* head = rcvd_samples_.head_;
+      rcvd_samples_.remove(head);
+      head->dec_ref();
+    }
+  }
+
+private:
+  /// Sequence number of the most recent data sample received
   SequenceNumber last_sequence_;
-
-  /// Data sample(s) in this instance
-  ReceivedDataElementList rcvd_samples_;
 
   /// ReceivedDataElementList strategy
   unique_ptr<ReceivedDataStrategy> rcvd_strategy_;
@@ -67,6 +651,37 @@ public:
   long deadline_timer_id_;
 
   MonotonicTimePoint last_accepted_;
+
+  /// Instance state for this instance
+  const InstanceState_rch instance_state_;
+
+  /// Data sample(s) in this instance
+  ReceivedDataElementList rcvd_samples_;
+
+  void read(ReceivedDataElement* rde,
+            InstanceStateUpdateList& isul)
+  {
+    if (rde->sample_state_ == DDS::NOT_READ_SAMPLE_STATE) {
+      rde->sample_state_ = DDS::READ_SAMPLE_STATE;
+      instance_state_->inc_read_count(isul);
+    }
+  }
+
+  bool remove(ReceivedDataElement* rde,
+              InstanceStateUpdateList& isul)
+  {
+    if (rde->sample_state_ == DDS::READ_SAMPLE_STATE) {
+      instance_state_->dec_read_count(isul);
+    } else {
+      instance_state_->dec_not_read_count(isul);
+    }
+    rcvd_samples_.remove(rde);
+    if (rcvd_samples_.size_ == 0 && instance_state_->release_pending() && instance_state_->no_writer()) {
+      isul.remove(instance_handle_);
+      return true;
+    }
+    return false;
+  }
 };
 
 typedef RcHandle<SubscriptionInstance> SubscriptionInstance_rch;

--- a/tests/DCPS/MockedTypeSupport/MyTypeSupportImpl.h
+++ b/tests/DCPS/MockedTypeSupport/MyTypeSupportImpl.h
@@ -125,7 +125,7 @@ public:
 
 #endif
 
-  void set_instance_state(DDS::InstanceHandle_t, DDS::InstanceStateKind,
+  void set_instance_state_i(DDS::InstanceHandle_t, DDS::InstanceStateKind,
     const OpenDDS::DCPS::SystemTimePoint&, const OpenDDS::DCPS::GUID_t& = OpenDDS::DCPS::GUID_UNKNOWN)
   {}
 };


### PR DESCRIPTION
Problem
-------

There are a number of brute-force loops in DataReaderImpl and
DataReaderImpl_T that cause read/take to be linear on the number of
instances.

Solution
--------

Index the instances by the combined sample-view-instance state.

Notes
-----

The DataReader implementation suffers from a lack of encapsulation.
There are a number of calls that originate in the DataReader, wander
through some intermediate classes, and then end up back at the
DataReader.  This makes understanding the code very difficult.  This
commit attempts to improve the implementation by encapsulating
SubcriptionInstance.  It is not perfect as you can see a DataReader
passed-in.